### PR TITLE
Custom derp server

### DIFF
--- a/charts/dz-control-plane/Readme.md
+++ b/charts/dz-control-plane/Readme.md
@@ -21,12 +21,13 @@
 
 ### Credentials Configuration
 
-| Name                   | Description            | Value |
-| ---------------------- | ---------------------- | ----- |
-| `credentials.registry` | Container registry URL | `""`  |
-| `credentials.username` | Registry username      | `""`  |
-| `credentials.password` | Registry password      | `""`  |
-| `credentials.email`    | Registry email address | `""`  |
+| Name                   | Description                   | Value       |
+| ---------------------- | ----------------------------- | ----------- |
+| `credentials.enable`   | Enable docker hub credentials | `true`      |
+| `credentials.registry` | Container registry URL        | `docker.io` |
+| `credentials.username` | Registry username             | `""`        |
+| `credentials.password` | Registry password             | `""`        |
+| `credentials.email`    | Registry email address        | `""`        |
 
 ### Image Configuration
 
@@ -178,8 +179,7 @@
 | `hydra.cidr.v4`                                                            | IPv4 CIDR range                                       | `100.64.0.0/10`                                                                                                        |
 | `hydra.derp.server.enabled`                                                | Enable DERP server                                    | `false`                                                                                                                |
 | `hydra.derp.urls`                                                          | DERP server URLs                                      | `["https://controlplane.tailscale.com/derpmap/default"]`                                                               |
-| `hydra.derp.paths`                                                         | DERP paths                                            | `[]`                                                                                                                   |
-| `hydra.derp.autoUpdateEnabled`                                             | Enable auto-update for DERP                           | `true`                                                                                                                 |
+| `hydra.derp.autoUpdateEnabled`                                             | endable derp map updates                              | `true`                                                                                                                 |
 | `hydra.derp.updateFrequency`                                               | Update frequency for DERP                             | `24h`                                                                                                                  |
 | `hydra.autoscaling.enabled`                                                | Enable autoscaling for Hydra                          | `false`                                                                                                                |
 | `hydra.autoscaling.minReplicas`                                            | Minimum autoscaling replicas for Hydra                | `1`                                                                                                                    |

--- a/charts/dz-control-plane/templates/hydra/hydra-cm.yaml
+++ b/charts/dz-control-plane/templates/hydra/hydra-cm.yaml
@@ -9,6 +9,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
 data:
+  {{- if .Values.hydra.derp.customderp }}
+  custom_derp.json: | 
+  {{- .Values.hydra.derp.customderp | trim | nindent 4}}
+  {{- end }}
   self_hosted.yaml: |
     server_url: https://hydra.{{ .Values.domain }}
     
@@ -30,6 +34,10 @@ data:
         stun_listen_addr: {{ .Values.hydra.derp.server.stunListenAddr }}
         private_key: {{ .Values.hydra.derp.server.privateKey }}
     
+      {{- if .Values.hydra.derp.customderp }}
+      paths:
+        - /etc/headscale/custom_derp.json
+      {{- else }}
       urls:
         {{- range .Values.hydra.derp.urls }}
           - {{ . | quote }}
@@ -38,6 +46,7 @@ data:
       paths:
       {{- range .Values.hydra.derp.paths }}
         - {{ . | quote }}
+      {{- end }}
       {{- end }}
       {{- end }}
       auto_update_enabled: {{ .Values.hydra.derp.autoUpdateEnabled | quote }}

--- a/charts/dz-control-plane/templates/hydra/hydra-deploy.yaml
+++ b/charts/dz-control-plane/templates/hydra/hydra-deploy.yaml
@@ -83,6 +83,11 @@ spec:
             - mountPath: /etc/headscale/self_hosted.yaml
               name: config
               subPath: self_hosted.yaml
+            {{- if .Values.hydra.derp.customderp }}
+            - mountPath: /etc/headscale/custom_derp.json
+              name: config
+              subPath: custom_derp.json
+            {{- end }}
           env:
             - name: HEADSCALE_CONFIG
               value: "/etc/headscale/self_hosted.yaml"

--- a/charts/dz-control-plane/values.schema.json
+++ b/charts/dz-control-plane/values.schema.json
@@ -20,10 +20,15 @@
         "credentials": {
             "type": "object",
             "properties": {
+                "enable": {
+                    "type": "boolean",
+                    "description": "Enable docker hub credentials",
+                    "default": true
+                },
                 "registry": {
                     "type": "string",
                     "description": "Container registry URL",
-                    "default": ""
+                    "default": "docker.io"
                 },
                 "username": {
                     "type": "string",
@@ -812,15 +817,9 @@
                                 "type": "string"
                             }
                         },
-                        "paths": {
-                            "type": "array",
-                            "description": "DERP paths",
-                            "default": [],
-                            "items": {}
-                        },
                         "autoUpdateEnabled": {
                             "type": "boolean",
-                            "description": "Enable auto-update for DERP",
+                            "description": "endable derp map updates",
                             "default": true
                         },
                         "updateFrequency": {

--- a/charts/dz-control-plane/values.yaml
+++ b/charts/dz-control-plane/values.yaml
@@ -409,7 +409,7 @@ hydra:
     #               "HostName": "your.hostname.com", // for private IP deployments, use the server IP
     #               "IPv4": "1.1.1.1",
     #               "IPv6": "1608:f740:f::ab",
-    #               "InsecureForTests": true // set this true for private IP deploys
+    #               "InsecureForTests": true // set this true for private IP deploys, false otherwise
     #             }
     #           ]
     #         }

--- a/charts/dz-control-plane/values.yaml
+++ b/charts/dz-control-plane/values.yaml
@@ -392,9 +392,28 @@ hydra:
     ## @param hydra.derp.urls DERP server URLs
     urls:
     - "https://controlplane.tailscale.com/derpmap/default"
-    ## @param hydra.derp.paths DERP paths
-    paths: []
-    ## @param hydra.derp.autoUpdateEnabled Enable auto-update for DERP
+    # for a custom derp server, include the following after deploying the server
+    # customderp: |
+    #   {
+    #       "Regions": {
+    #         "901": {
+    #           "RegionID": 901,
+    #           "RegionCode": "nyc", // can be set to anything, keep human readable
+    #           "RegionName": "New York City", // change to derp server deployment geolocation
+    #           "Latitude": 40.7128, // change to derp server deployment geolocation
+    #           "Longitude": -74.006, // change to derp server deployment geolocation
+    #           "Nodes": [
+    #             {
+    #               "Name": "901a", 
+    #               "RegionID": 901,
+    #               "HostName": "your.hostname.com", // for private IP deployments, use the server IP
+    #               "IPv4": "1.1.1.1",
+    #               "IPv6": "1608:f740:f::ab",
+    #             }
+    #           ]
+    #         }
+    #     }
+    #   }
     autoUpdateEnabled: true
     ## @param hydra.derp.updateFrequency Update frequency for DERP
     updateFrequency: "24h"

--- a/charts/dz-control-plane/values.yaml
+++ b/charts/dz-control-plane/values.yaml
@@ -409,6 +409,7 @@ hydra:
     #               "HostName": "your.hostname.com", // for private IP deployments, use the server IP
     #               "IPv4": "1.1.1.1",
     #               "IPv6": "1608:f740:f::ab",
+    #               "InsecureForTests": true // set this true for private IP deploys
     #             }
     #           ]
     #         }

--- a/charts/dz-control-plane/values.yaml
+++ b/charts/dz-control-plane/values.yaml
@@ -415,6 +415,7 @@ hydra:
     #         }
     #     }
     #   }
+    ## @param hydra.derp.autoUpdateEnabled endable derp map updates
     autoUpdateEnabled: true
     ## @param hydra.derp.updateFrequency Update frequency for DERP
     updateFrequency: "24h"

--- a/terraform/modules/derp/aws/derp-init.tpl
+++ b/terraform/modules/derp/aws/derp-init.tpl
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -euo pipefail
+
+
+# Update system
+apt-get update
+apt-get install -y curl golang certbot openssl
+export HOME=/home/ubuntu
+export GOPATH=$HOME/go
+export PATH=$PATH:$GOPATH/bin
+
+# Install Tailscale
+/usr/bin/go install tailscale.com/cmd/derper@main
+cp home/ubuntu/go/bin/derper /usr/bin/
+
+
+%{ if !public_derp }
+export DERP_PRIVATE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4/)
+mkdir -p /etc/derper
+openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout /etc/derper/$DERP_PRIVATE_IP.key -out /etc/derper/$DERP_PRIVATE_IP.crt -subj "/CN=$DERP_PRIVATE_IP" -addext "subjectAltName=IP:$DERP_PRIVATE_IP"
+%{ endif }
+
+
+# Create systemd service
+cat <<EOT > /etc/systemd/system/derper.service
+[Unit]
+Description=Devzero DERP Server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=root
+ExecStart=/usr/bin/derper %{ if public_derp }-hostname ${hostname}%{ else }-hostname $DERP_PRIVATE_IP -certmode manual -certdir /etc/derper/ %{ endif } 
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOT
+
+# Enable and start the service
+systemctl daemon-reload
+systemctl enable derper
+systemctl start derper

--- a/terraform/modules/derp/aws/main.tf
+++ b/terraform/modules/derp/aws/main.tf
@@ -1,0 +1,225 @@
+# Local variables for conditional logic
+locals {
+  create_vpc            = var.existing_vpc_id == ""
+  create_subnet         = var.existing_subnet_id == ""
+  create_security_group = var.existing_security_group_id == ""
+  create_eip            = var.public_derp && var.existing_eip_id == ""
+
+
+  # Use existing or created EIP ID
+  eip_id = local.create_eip ? aws_eip.derp_eip[0].id : var.existing_eip_id
+  # Use existing or created VPC ID
+  vpc_id = local.create_vpc ? aws_vpc.derp_vpc[0].id : var.existing_vpc_id
+  # Use existing or created subnet ID
+  subnet_id = local.create_subnet ? aws_subnet.derp_subnet[0].id : var.existing_subnet_id
+  # Use existing or created security group ID
+  security_group_id = local.create_security_group ? aws_security_group.derp_sg[0].id : var.existing_security_group_id
+
+  # Common tags
+  common_tags = {
+    Component = "devzero-derp"
+  }
+}
+
+# Configure AWS Provider
+provider "aws" {
+  region = var.aws_region
+}
+
+# Create Elastic IP
+resource "aws_eip" "derp_eip" {
+  count  = local.create_eip ? 1 : 0
+  domain = "vpc"
+
+  tags = merge(local.common_tags, {
+    Name = "devzero-derp-eip"
+  })
+}
+
+# Associate Elastic IP with EC2 instance
+resource "aws_eip_association" "derp_eip_assoc" {
+  count         = var.public_derp ? 1 : 0
+  instance_id   = aws_instance.derp_server.id
+  allocation_id = local.eip_id
+}
+
+
+# Create VPC if no existing VPC ID provided
+resource "aws_vpc" "derp_vpc" {
+  count = local.create_vpc ? 1 : 0
+
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(local.common_tags, {
+    Name = "devzero-derp-vpc"
+  })
+}
+
+# Create Internet Gateway if creating VPC
+resource "aws_internet_gateway" "derp_igw" {
+  count = local.create_vpc ? 1 : 0
+
+  vpc_id = local.vpc_id
+
+  tags = merge(local.common_tags, {
+    Name = "devzero-derp-igw"
+  })
+}
+
+# Create Public Subnet if no existing subnet ID provided
+resource "aws_subnet" "derp_subnet" {
+  count = local.create_subnet ? 1 : 0
+
+  vpc_id                  = local.vpc_id
+  cidr_block              = "10.0.1.0/24"
+  map_public_ip_on_launch = true
+  availability_zone       = "${var.aws_region}a"
+
+  tags = merge(local.common_tags, {
+    Name = "devzero-derp-subnet"
+  })
+}
+
+# Create Route Table if creating VPC
+resource "aws_route_table" "derp_rt" {
+  count = local.create_vpc ? 1 : 0
+
+  vpc_id = local.vpc_id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.derp_igw[0].id
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "devzero-derp-rt"
+  })
+}
+
+# Associate Route Table with Subnet if creating both
+resource "aws_route_table_association" "derp_rta" {
+  count = local.create_subnet && local.create_vpc ? 1 : 0
+
+  subnet_id      = local.subnet_id
+  route_table_id = aws_route_table.derp_rt[0].id
+}
+
+# Create Security Group if no existing security group ID provided
+resource "aws_security_group" "derp_sg" {
+  count = local.create_security_group ? 1 : 0
+
+  name        = "devzero-derp-security-group"
+  description = "Security group for DERP server"
+  vpc_id      = local.vpc_id
+
+  ingress {
+    from_port   = 3478
+    to_port     = 3478
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = var.ssh_cidr_blocks
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "devzero-derp-sg"
+  })
+}
+
+# Create EC2 Instance
+resource "aws_instance" "derp_server" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = var.instance_type
+  key_name      = var.ssh_key_name
+
+  subnet_id                   = local.subnet_id
+  vpc_security_group_ids      = [local.security_group_id]
+  metadata_options {
+    http_tokens = "optional"
+  }
+
+  root_block_device {
+    volume_size = var.volume_size
+    volume_type = "gp3"
+  }
+
+  user_data = templatefile("${path.module}/derp-init.tpl", {
+    hostname = var.hostname
+    public_derp = var.public_derp
+  })
+
+  tags = merge(local.common_tags, {
+    Name = "devzero-derp-server"
+  })
+}
+
+# Data source for latest Ubuntu AMI
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+# Data source for existing EIP if provided
+data "aws_eip" "existing" {
+  count = var.existing_eip_id != "" ? 1 : 0
+  id    = var.existing_eip_id
+}
+
+output "derp_server_elastic_ip" {
+  value = var.public_derp ? local.create_eip ? aws_eip.derp_eip[0].public_ip : data.aws_eip.existing[0].public_ip : null
+}
+
+output "derp_server_elastic_ip_id" {
+  value = var.public_derp ? local.eip_id : null
+}
+
+output "derp_server_private_ip" {
+  value = aws_instance.derp_server.private_ip
+}
+
+output "derp_server_public_ip" {
+  value = aws_instance.derp_server.public_ip
+}
+
+output "vpc_id" {
+  value = local.vpc_id
+}
+
+output "subnet_id" {
+  value = local.subnet_id
+}
+
+output "security_group_id" {
+  value = local.security_group_id
+}

--- a/terraform/modules/derp/aws/variables.tf
+++ b/terraform/modules/derp/aws/variables.tf
@@ -1,0 +1,65 @@
+variable "aws_region" {
+  description = "AWS region to deploy resources"
+  type        = string
+  default     = ""
+}
+
+variable "instance_type" {
+  description = "EC2 instance type 'm6in.2xlarge' recommended for bandwidth intensive deployments"
+  type        = string
+  default     = "t2.medium" 
+}
+
+variable "volume_size" {
+  description = "Root volume size in GB"
+  type        = number
+  default     = 20
+}
+
+variable "ssh_key_name" {
+  description = "ssh keypair name"
+  type        = string
+  default     = ""
+}
+
+variable "hostname" {
+  description = "server host name, required for public derps"
+  type        = string
+  default     = "" 
+}
+
+variable "public_derp" {
+  description = "associates EIP with server instance"
+  type        = bool
+  default     = false
+}
+
+variable "existing_vpc_id" {
+  description = "Existing VPC ID to use (optional)"
+  type        = string
+  default     = ""
+}
+
+variable "existing_eip_id" {
+  description = "Existing Elastic IP allocation ID to use (optional)"
+  type        = string
+  default     = ""
+}
+
+variable "existing_subnet_id" {
+  description = "Existing subnet ID to use (optional)"
+  type        = string
+  default     = ""
+}
+
+variable "existing_security_group_id" {
+  description = "Existing security group ID to use (optional)"
+  type        = string
+  default     = ""
+}
+
+variable "ssh_cidr_blocks" {
+  description = "CIDR blocks for SSH access"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}

--- a/terraform/modules/derp/vpc/main.tf
+++ b/terraform/modules/derp/vpc/main.tf
@@ -1,0 +1,139 @@
+locals {
+  # Use existing or created VPC ID
+  vpc_id = aws_vpc.derp_vpc.id
+  # Use existing or created subnet ID
+  subnet_id = aws_subnet.derp_subnet.id
+  # Use existing or created security group ID
+  security_group_id = aws_security_group.derp_sg.id 
+  aws_region = "us-west-2"
+
+}
+
+# Configure AWS Provider
+provider "aws" {
+  region = "us-west-2"
+}
+
+# Create VPC if no existing VPC ID provided
+resource "aws_vpc" "derp_vpc" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+# Create Internet Gateway if creating VPC
+resource "aws_internet_gateway" "derp_igw" {
+  vpc_id = local.vpc_id
+}
+
+# Create Public Subnet if no existing subnet ID provided
+resource "aws_subnet" "derp_subnet" {
+  vpc_id                  = local.vpc_id
+  cidr_block              = "10.0.1.0/24"
+  map_public_ip_on_launch = true
+  availability_zone       = "${local.aws_region}a"
+}
+
+# Create Route Table if creating VPC
+resource "aws_route_table" "derp_rt" {
+  vpc_id = local.vpc_id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.derp_igw.id
+  }
+}
+
+# Associate Route Table with Subnet if creating both
+resource "aws_route_table_association" "derp_rta" {
+  subnet_id      = local.subnet_id
+  route_table_id = aws_route_table.derp_rt.id
+}
+
+# Create Security Group if no existing security group ID provided
+resource "aws_security_group" "derp_sg" {
+  name        = "devzero-derp-security-group"
+  description = "Security group for DERP server"
+  vpc_id      = local.vpc_id
+
+  ingress {
+    from_port   = 3478
+    to_port     = 3478
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["10.0.1.0/24"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# Data source for latest Ubuntu AMI
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_instance" "derp_server" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = "t2.medium"
+  key_name      = "kevinkeyeng"
+  associate_public_ip_address = true
+
+  subnet_id                   = local.subnet_id
+  vpc_security_group_ids      = [local.security_group_id]
+  metadata_options {
+    http_tokens = "optional"
+  }
+
+  root_block_device {
+    volume_size = 20
+    volume_type = "gp3"
+  }
+}
+
+output "vpc_id" {
+  value = local.vpc_id
+}
+
+output "subnet_id" {
+  value = local.subnet_id
+}
+
+output "security_group_id" {
+  value = local.security_group_id
+}


### PR DESCRIPTION
Provides a custom derp server for self hosted deployments. 

User should deploy the terraform module first, then and the config values into the hydra deployment and spin up the control plane. 

Supports both public and private derps, supports user provided vpc, security group and subnets. 

For public derps, the hostname variable is required to be a user owned domain that the user will associate with server public IP.  Tailscale derps automatically obtain a cert via HTTP-01 from LetsEncrypt. 

For private derps, the derp will spin up with a self signed certificate and listen at the private IP of the ec2 instance. 
The self signed cert is not strictly required for now as we will set "InsecureForTests" skipping TLS, This *mostly* fine see [here](https://github.com/tailscale/tailscale/issues/12107). Tailscale themselves are currently in the [middle of writing code](https://github.com/tailscale/tailscale/issues/11776#issuecomment-2520955317) for supporting self signed certs for derps on the client side, secured with a cert fingerprint. Just setting up the cert for now in the deployments so if/when the full support comes from tailscale we can move to use it with just a config change. 

