### PR TITLE
added function for dzi check data-plane prometheus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ dz_config.json
 
 # Ignore files created by permission helper
 terraform/examples/aws/permission-helper/permissions/*.json
+
+venv/

--- a/charts/dz-data-plane-deps/values/prometheus.yaml
+++ b/charts/dz-data-plane-deps/values/prometheus.yaml
@@ -1,6 +1,6 @@
 # https://github.com/prometheus-community/helm-charts/blob/prometheus-26.0.1/charts/prometheus/values.yaml
 
-extraScrapeConfigs:
+extraScrapeConfigs: |
   - job_name: "cortex"
     metrics_path: "/metrics"
     kubernetes_sd_configs:

--- a/dz_installer/data_plane.py
+++ b/dz_installer/data_plane.py
@@ -30,6 +30,5 @@ class DataPlane:
             error(f"Error checking Prometheus chart: {e}")
             return
 
-        # Store the information in CLI state file
         cfg.save()
         success("Data Plane Prometheus checks")

--- a/dz_installer/data_plane.py
+++ b/dz_installer/data_plane.py
@@ -1,0 +1,35 @@
+from kubernetes import client, config
+from dz_installer.dz_config import DZConfig
+from dz_installer.helpers import info, success, error, check_chart_is_installed
+import click
+
+class DataPlane:
+    @staticmethod
+    def check_data_plane_prometheus(force):
+        """Check if the Prometheus Helm chart is installed and prompt for installation if missing."""
+        info("Checking Prometheus installation in the data plane...")
+
+        chart_name = "prometheus"
+        cfg = DZConfig().data
+
+        if cfg.data_plane.prometheus_installed and not force:
+            click.echo("Prometheus is already installed. Skipping check...")
+            return
+
+        try:
+            if check_chart_is_installed(chart_name):
+                success("Prometheus chart is installed.")
+                cfg.data_plane.prometheus_installed = True
+            else:
+                click.echo("Prometheus chart is not installed.")
+                install = click.confirm("Do you want to install Prometheus?", default=True)
+                if not install:
+                    click.echo("Cannot proceed without Prometheus.")
+                    return
+        except RuntimeError as e:
+            error(f"Error checking Prometheus chart: {e}")
+            return
+
+        # Store the information in CLI state file
+        cfg.save()
+        success("Data Plane Prometheus checks")

--- a/dzi
+++ b/dzi
@@ -4,6 +4,7 @@ import collections
 
 import click
 
+from dz_installer.data_plane import DataPlane
 from dz_installer.dz_config import DZConfig
 from dz_installer.helpers import get_provider, info
 from dz_installer.control_plane import ControlPlane
@@ -218,9 +219,12 @@ def check_data_plane_metacontroller():
 
 
 @check_data_plane.command("prometheus")
-def check_data_plane_prometheus():
+@click.option(
+    "--force", is_flag=True, help="Force run checks even if already checked before"
+)
+def check_data_plane_prometheus(force):
     """Helm chart: prometheus"""
-    click.echo("Checking helm chart: prometheus")
+    DataPlane().check_data_plane_prometheus(force)
 
 @cli.group(name="install")
 @click.option(


### PR DESCRIPTION
**CLI Outputs:**

```
$ ./dzi check data-plane prometheus
ℹ Checking Prometheus installation in the data plane...
ℹ Running command: helm list
✓ Prometheus chart is installed.
✓ Data Plane Prometheus checks
```
```
$ ./dzi check data-plane prometheus
ℹ Checking Prometheus installation in the data plane...
Prometheus is already installed. Skipping check...
```

**When prometheus chart is not installed:**

```
$ ./dzi check data-plane prometheus --force
ℹ Checking Prometheus installation in the data plane...
ℹ Running command: helm list
Prometheus chart is not installed.
Do you want to install Prometheus? [Y/n]: y
✓ Data Plane Prometheus checks
```
```
$ ./dzi check data-plane prometheus --force
ℹ Checking Prometheus installation in the data plane...
ℹ Running command: helm list
Prometheus chart is not installed.
Do you want to install Prometheus? [Y/n]: n
Cannot proceed without Prometheus.
```