### PR TITLE
[new-release] Update dz-control-plane image tag to v1.0.2

### DIFF
--- a/charts/dz-control-plane/values.yaml
+++ b/charts/dz-control-plane/values.yaml
@@ -42,7 +42,7 @@ image:
   ## @param image.repository Devzero container image repository
   repository: docker.io/devzeroinc
   ## @param image.tag Devzero container image tag
-  tag: "v1.0.1"
+  tag: "v1.0.2"
   ## @param image.pullPolicy Container pull policy
   pullPolicy: IfNotPresent
   # -- Optionally specify an array of imagePullSecrets


### PR DESCRIPTION
This PR updates the dz-control-plane image tag in values.yaml to v1.0.2.