### PR TITLE
[new-release] Update dz-control-plane image tag to v1.0.2

### DIFF
--- a/charts/dz-control-plane/README.md
+++ b/charts/dz-control-plane/README.md
@@ -143,7 +143,7 @@ The Helm chart installs the following components:
 | ------------------- | ----------------------------------------------- | ---------------------- |
 | `image.repository`  | Devzero container image repository              | `docker.io/devzeroinc` |
 | `image.repository`  | Devzero container image repository              | `docker.io/devzeroinc` |
-| `image.tag`         | Devzero container image tag                     | `v1.0.1`               |
+| `image.tag`         | Devzero container image tag                     | `v1.0.2`               |
 | `image.pullPolicy`  | Container pull policy                           | `IfNotPresent`         |
 | `image.pullSecrets` | Optionally specify an array of imagePullSecrets | `["pull-secret"]`      |
 

--- a/charts/dz-control-plane/values.schema.json
+++ b/charts/dz-control-plane/values.schema.json
@@ -68,7 +68,7 @@
                 "tag": {
                     "type": "string",
                     "description": "Devzero container image tag",
-                    "default": "v1.0.1"
+                    "default": "v1.0.2"
                 },
                 "pullPolicy": {
                     "type": "string",

--- a/charts/dz-control-plane/values.yaml
+++ b/charts/dz-control-plane/values.yaml
@@ -42,7 +42,7 @@ image:
   ## @param image.repository Devzero container image repository
   repository: docker.io/devzeroinc
   ## @param image.tag Devzero container image tag
-  tag: "v1.0.1"
+  tag: "v1.0.2"
   ## @param image.pullPolicy Container pull policy
   pullPolicy: IfNotPresent
   # -- Optionally specify an array of imagePullSecrets


### PR DESCRIPTION
This PR updates the dz-control-plane image tag in values.yaml to v1.0.2.